### PR TITLE
优先使用全局 LLM 配置并在失效时回退到 agent 覆盖模型

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 ## 快速开始
 
+### macOS / Linux
+
 ```bash
 # 安装
 pip install -e ".[dev]"
@@ -19,6 +21,29 @@ autoflow run dev-pipeline --input "实现一个快速排序函数"
 
 # 启动守护进程
 autoflow start --daemon
+```
+
+### Windows (PowerShell)
+
+```powershell
+# （可选）创建并激活虚拟环境
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+
+# 安装
+pip install -e ".[dev]"
+
+# 配置 API Key（仅当前会话）
+$env:OPENAI_API_KEY = "your_api_key"
+
+# 查看系统状态
+python -m autoflow status
+
+# 运行工作流
+python -m autoflow run dev-pipeline --input "实现一个快速排序函数"
+
+# 启动守护进程（Ctrl+C 退出）
+python -m autoflow start --daemon
 ```
 
 ## 项目结构

--- a/src/autoflow/llm/gateway.py
+++ b/src/autoflow/llm/gateway.py
@@ -52,6 +52,48 @@ class LLMGateway:
         # 关闭 litellm 自带的冗余日志
         litellm.suppress_debug_info = True
 
+    def _validate_model_config(self, config: ModelConfig | None) -> tuple[bool, str | None]:
+        """检查模型配置是否可用"""
+        if config is None:
+            return False, "missing_config"
+        if not config.provider or not config.provider.strip():
+            return False, "missing_provider"
+        if not config.name or not config.name.strip():
+            return False, "missing_model_name"
+        if config.max_tokens <= 0:
+            return False, "invalid_max_tokens"
+        if config.api_key_env is not None and not config.api_key_env.strip():
+            return False, "invalid_api_key_env"
+        return True, None
+
+    def _select_model_config(
+        self,
+        override: ModelConfig | None,
+        prefer_default: bool,
+    ) -> ModelConfig:
+        """决定本次调用使用的模型配置"""
+        if prefer_default:
+            default_ok, default_reason = self._validate_model_config(self._default_model)
+            if default_ok:
+                return self._default_model
+            logger.warning(
+                "llm.default_model_invalid",
+                reason=default_reason,
+            )
+
+        if override:
+            override_ok, override_reason = self._validate_model_config(override)
+            if override_ok:
+                if prefer_default:
+                    logger.info("llm.agent_model_fallback", reason=override_reason)
+                return override
+            logger.error(
+                "llm.agent_model_invalid",
+                reason=override_reason,
+            )
+
+        raise LLMUnavailableError("No valid LLM model configuration available")
+
     def _resolve_model_string(self, config: ModelConfig) -> str:
         """构建 litellm 识别的模型字符串
 
@@ -86,6 +128,7 @@ class LLMGateway:
         messages: list[dict],
         model_config: ModelConfig | None = None,
         tools: list[dict] | None = None,
+        prefer_default: bool = True,
         **kwargs,
     ) -> LLMResponse:
         """统一 LLM 调用入口
@@ -94,12 +137,13 @@ class LLMGateway:
             messages: OpenAI 格式的消息列表
             model_config: 模型配置，不传则使用默认配置
             tools: Function Calling 工具定义
+            prefer_default: 是否优先尝试全局默认模型
             **kwargs: 传递给 litellm 的额外参数
 
         Returns:
             LLMResponse 包含回复内容和 Token 用量
         """
-        config = model_config or self._default_model
+        config = self._select_model_config(model_config, prefer_default=prefer_default)
 
         # 预算检查
         if self.token_tracker.is_budget_exceeded():
@@ -179,7 +223,12 @@ class LLMGateway:
                     api_base=original_config.api_base,
                     api_key_env=original_config.api_key_env,
                 )
-                return await self.chat(messages, model_config=fallback_config, **kwargs)
+                return await self.chat(
+                    messages,
+                    model_config=fallback_config,
+                    prefer_default=False,
+                    **kwargs,
+                )
             except Exception as fallback_err:
                 logger.error(
                     "llm.fallback_failed",


### PR DESCRIPTION
新增 _validate_model_config，统一校验模型配置合法性（provider、model name、max_tokens、api_key_env 等） 新增 _select_model_config，封装模型选择策略
在 prefer_default=True 时优先尝试项目级默认 LLM 配置
默认配置不可用时记录 warning 并尝试 agent 传入的覆盖模型
覆盖模型无效时记录 error，最终抛出 LLMUnavailableError
通过结构化日志标记默认模型失效与 agent 模型回退场景，便于排查配置问题